### PR TITLE
Remove python3.7 support as EOL is 27.06.2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 .groovylintrc.json
 *jobs*.xlsx
 __pycache__

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 /* groovylint-disable NestedBlockDepth */
 Map parallelStages = [:]
-pythonsArray = ['3.7', '3.8', '3.9', '3.10', '3.11']
+pythonsArray = ['3.8', '3.9', '3.10', '3.11']
 testStage = 'jobScrapperCI/run_tests'
 runStage = 'jobScrapperCI/run_scrapper'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 beautifulsoup4==4.12.2
 openpyxl==3.1.2
-pandas==1.3.5; python_version == '3.7'
-pandas==2.0.2; python_version > '3.7'
+pandas==2.0.2
 pytest==7.4.0
 Requests==2.31.0
 pytest-html==3.2.0


### PR DESCRIPTION
![image](https://github.com/wkobiela/jobScrapper/assets/12174429/f8dcb085-df96-43f4-8f57-dbb9d15324f0)
![image](https://github.com/wkobiela/jobScrapper/assets/12174429/5ef84c7d-88ed-4e5c-a78b-469855dce51c)
https://devguide.python.org/versions/